### PR TITLE
corrige estabilidade no código do merge sort

### DIFF
--- a/content/posts/merge-sort.md
+++ b/content/posts/merge-sort.md
@@ -49,7 +49,7 @@ O código do método ***merge*** está descrito abaixo. Vamos analisar por parte
         
         while (i <= middle && j <= right) {
             
-            if (helper[i] < helper[j]) {
+            if (helper[i] <= helper[j]) {
                 v[k] = helper[i];
                 i++;
             } else {
@@ -112,7 +112,7 @@ Agora, o algoritmo passa a tratar da comparação entre $helper[i]$ e $helper[j]
 ...
     while (i <= middle && j <= right) {
             
-        if (helper[i] < helper[j]) {
+        if (helper[i] <= helper[j]) {
             v[k] = helper[i];
             i++;
         } else {


### PR DESCRIPTION
Para o Merge Sort ser estável, na comparação do merge deve ser feita a verificação se o elemento mais à esquerda é `<=` ao elemento mais à direita, com o objetivo de, em caso de existir dois elementos iguais, o mais à esquerda continuar na esquerda. Se a verificação for somente com `<` o algoritmo não será estável, levando o elemento da direita para frente.