### PR TITLE
fix: corrige indice do topo na pilha

### DIFF
--- a/content/posts/lifoarray.md
+++ b/content/posts/lifoarray.md
@@ -57,7 +57,7 @@ Adicionando "a" na pilha (push):
 
 pilha = [<font color="blue">"a"</font>, <font color="red">null, null</font>]; `topo` = 0;
 
-Neste momento, o topo da pilha está no índice 1. Então, nossa pilha está destacada em azul. Tem apenas o elemento "a".
+Neste momento, o topo da pilha está no índice 0. Então, nossa pilha está destacada em azul. Tem apenas o elemento "a".
 
 Adicionando "b" na pilha (push):
 


### PR DESCRIPTION
Na seção de operações, o índice em que o topo da pilha se encontra está como 1, deveria ser 0.