### PR TITLE
chore: ajusta tamanho do array auxiliar no merge

### DIFF
--- a/content/posts/merge-sort.md
+++ b/content/posts/merge-sort.md
@@ -17,7 +17,7 @@ O funcionamento do Merge Sort baseia-se em uma rotina fundamental cujo nome é *
 
 # Merge
 
-Merge é a rotina que combina dois arrays ordenados em um outro também ordenado. Assim como o <a class="external" href="https://joaoarthurbm.github.io/eda/posts/quick-sort/">Quick Sort</a> aplica várias vezes o particionamento para ordenar um array, o Merge Sort também aplica o Merge várias para ordenar um array. 
+Merge é a rotina que combina dois arrays ordenados em um outro também ordenado. Assim como o <a class="external" href="https://joaoarthurbm.github.io/eda/posts/quick-sort/">Quick Sort</a> aplica várias vezes o particionamento para ordenar um array, o Merge Sort também aplica o Merge várias vezes para ordenar um array. 
 
 A ideia é simples e é explicada visualmente no vídeo abaixo.
 
@@ -34,20 +34,22 @@ O código do método ***merge*** está descrito abaixo. Vamos analisar por parte
 
 ```java
 ...
-    public void merge(int[] v, int left, int middle, int right) {
+    public void merge(int[] v, int left, int right) {
         
         // transfere os elementos entre left e right para um array auxiliar.
-        int[] helper = new int[v.length];
-        for (int i = left; i <= right; i++) {
-            helper[i] = v[i];
+        int rightHelper = right - left;
+        int[] helper = new int[rightHelper + 1];
+        for (int i = 0; i <= rightHelper; i++) {
+            helper[i] = v[left + i];
         }
         
-        
-        int i = left;
-        int j = middle + 1;
+        int middleHelper = rightHelper / 2;
+    
+        int i = 0;
+        int j = middleHelper + 1;
         int k = left;
         
-        while (i <= middle && j <= right) {
+        while (i <= middleHelper && j <= rightHelper) {
             
             if (helper[i] <= helper[j]) {
                 v[k] = helper[i];
@@ -56,12 +58,12 @@ O código do método ***merge*** está descrito abaixo. Vamos analisar por parte
                 v[k] = helper[j];
                 j++;
             }
-            k++;    
             
+            k++;
         }
         
         // se a metade inicial não foi toda consumida, faz o append.
-        while (i <= middle) {
+        while (i <= middleHelper) {
             v[k] = helper[i];
             i++;
             k++;
@@ -75,21 +77,32 @@ O código do método ***merge*** está descrito abaixo. Vamos analisar por parte
 ...
 ```
 
-Em primeiro lugar, vamos entender a assinatura do método ***merge***. Naturalmente, ele recebe como parâmetro o array a ser processado. Recebe também três índices: `left` e `middle` e `right`, que determinam os limites em que o algoritmo deve agir. 
+Em primeiro lugar, vamos entender a assinatura do método ***merge***. Naturalmente, ele recebe como parâmetro o array a ser processado. Recebe também dois índices: `left` e `right`, que determinam os limites em que o algoritmo deve agir. 
 
-Se você prestou atenção no vídeo anterior, sabe que a parte do array que é delimitada por `left` e `middle` está ordenada e sabe que a parte do array delimitada por `middle + 1` e `right` também está ordenada. Veja a figura abaixo que ilustra essa situação. Nosso trabalho é fazer a junção (merge) dessas duas partes em uma sequência ordenada.
+Se você prestou atenção no vídeo anterior, sabe que a parte do array que é delimitada por `left` e `middle` — onde $middle = (right + left) / 2$ — está ordenada e sabe que a parte do array delimitada por `middle + 1` e `right` também está ordenada. Veja a figura abaixo que ilustra essa situação. Nosso trabalho é fazer a junção (merge) dessas duas partes em uma sequência ordenada.
 
 ![partes](partes.png)
 
-Para isso, como fazer manipulações em nosso array original, precisamos de um array auxiliar (`helper`) para guardar o estado. Isso é feito nas três primeiras linhas do método.
+Para isso, como vamos manipular nosso array original, precisamos de um array auxiliar (`helper`) para guardar o estado. Isso é feito nas quatro primeiras linhas do método.
+
+**Nota:** Nem sempre é preciso criar um array auxiliar do mesmo tamanho que o array original. Por isso, calculamos o valor de `rightHelper` e definimos o tamanho do auxiliar como `rightHelper + 1`, para que ele tenha apenas o tamanho necessário para transferir os elementos entre `left` e `right`.
 
 ```java
 ...
     // transfere os elementos entre left e right para um array auxiliar.
-    int[] helper = new int[v.length];
-    for (int i = left; i <= right; i++) {
-        helper[i] = v[i];
-    }     
+    int rightHelper = right - left;
+    int[] helper = new int[rightHelper + 1];
+    for (int i = 0; i <= rightHelper; i++) {
+        helper[i] = v[left + i];
+    }    
+...
+```
+
+Após criar o array auxiliar, calculamos o valor de `middleHelper`. Esse valor representa o ponto médio do array auxiliar e é usado para dividir virtualmente as duas partes ordenadas.
+
+```java
+...
+    int middleHelper = rightHelper / 2;
 ...
 ```
 
@@ -97,17 +110,17 @@ As próximas linhas definem os valores de `i`, `j` e `k` que, como visto no víd
 
  ```java
 ...
-    int i = left;
-    int j = middle + 1;
-    int k = left;    
+    int i = 0;
+    int j = middleHelper + 1;
+    int k = left;
 ...
 ```
 
-Agora, o algoritmo passa a tratar da comparação entre $helper[i]$ e $helper[j]$ para adicionar o menor em $v[k]$. Lembre-se: se $helper[i]$ for menor ou igual, `v[k] = helper[i]` e `i` e `k` são incrementados. Caso contrário, `v[k] = helper[j]` e `j` e `k` são incrementados. Isso é feito até que uma das partes tenha sido completamente percorrida, isto é, se `i` atingir `middle` ou `j` atingir `right`.
+Agora, o algoritmo passa a tratar da comparação entre $helper[i]$ e $helper[j]$ para adicionar o menor em $v[k]$. Lembre-se: se $helper[i]$ for menor ou igual, `v[k] = helper[i]` e `i` e `k` são incrementados. Caso contrário, `v[k] = helper[j]` e `j` e `k` são incrementados. Isso é feito até que uma das partes tenha sido completamente percorrida, isto é, se `i` atingir `middleHelper` ou `j` atingir `rightHelper`.
 
 ```java
 ...
-    while (i <= middle && j <= right) {
+    while (i <= middleHelper && j <= rightHelper) {
             
         if (helper[i] <= helper[j]) {
             v[k] = helper[i];
@@ -116,7 +129,7 @@ Agora, o algoritmo passa a tratar da comparação entre $helper[i]$ e $helper[j]
             v[k] = helper[j];
             j++;
         }
-        k++;    
+        k++;
             
     }
 ...
@@ -125,14 +138,14 @@ Agora, o algoritmo passa a tratar da comparação entre $helper[i]$ e $helper[j]
 Por fim, como vimos em detalhe no vídeo. Uma das duas partes do array será consumida em sua totalidade antes da outra. Se for a metade inicial, basta então, fazermos o *append* de todos os elementos faltantes até o meio. Isso é feito pelo código abaixo.
 
 ```java
-    ...
+...
     // se a metade inicial não foi toda consumida, faz o append.
-    while (i <= middle) {
+    while (i <= middleHelper) {
         v[k] = helper[i];
         i++;
         k++;
     }
-    ...
+...
 ```
 
 Não precisamos nos preocupar caso os elementos que sobrarem for da metade final, uma vez que eles já estão, e em ordem, no array original. Em versões antigas desse material, eu incluia o while dessa parte também, mas, de fato, não é preciso. Importante destacar que essa foi uma contribuição de uma aluna da turma de disciplina em 2023.2 que, em sala de aula, levantou o questionamento e gerou o debate.
@@ -148,7 +161,7 @@ Como dito, o Merge Sort é um algoritmo de divisão-e-conquista. A parte da conq
 A parte da divisão, na verdade, é bem simples. Basta "dividir" o array recursivamente na metade até que sobre apenas um elemento. Note que usei aspas em dividir. Isso porque a gente não divide de fato. Não cria dois arrays e transfere todos os elementos. Seria muito custoso. O que a gente faz é usar os índices `left`, `middle` e `right` para controlar as partes do array que o algoritmo deve agir. Vamos ver o código:
 
 ```java
-public void mergeSort(int[] v, int left, int right) {   
+    public void mergeSort(int[] v, int left, int right) {   
         
         if (left >= right)
             return;
@@ -159,7 +172,7 @@ public void mergeSort(int[] v, int left, int right) {
             mergeSort(v, left, middle);
             mergeSort(v, middle + 1, right);
     
-            merge(v, left, middle, right);
+            merge(v, left, right);
         }
         
     }
@@ -172,25 +185,25 @@ Seguindo. Na primeira linha do método, temos a condição de parada do algoritm
 Caso ainda seja necessário "quebrar" o array (`if left < right`), temos essas quatro linhas bem importantes:
 
 ```java
-    ...
+...
     int middle = (left + right) / 2;
     mergeSort(v, left, middle);
     mergeSort(v, middle + 1, right);
 
-    merge(v, left, middle, right);
-    ...
+    merge(v, left, right);
+...
 ```
 
 A primeira define `middle` como sendo o valor central entre `left` e `right`. A segunda e a terceira são chamadas recursivas para a metade da esquerda (de ***left*** até ***middle***) e para a metade da direita (de ***middle + 1*** até ***right***).
 
-Por fim, após cada quebra há uma chamada ao método merge, passando os limites a serem considerados (***left***, ***middle***, ***right***).
+Por fim, após cada quebra há uma chamada ao método merge, passando os limites a serem considerados (***left*** e ***right***).
 
 
 [^1]: Certamente eu poderia ter feito `if (left < right)` e economizado algumas linhas de código descartando o else. Contudo, eu prefiro dessa maneira para fins didáticos.
 
 ## Análise do Tempo de Execução
 
-Lembra dos passos para determinar o tempo de execução de <a class="external" href="https://joaoarthurbm.github.io/eda/posts/analise-algoritmos-recursivos/">algoritmos recursivos?</a>. O primeiro passo é encontrar a relação de recorrência. O Merge Sort possui duas chamadas recursivas, cada uma reduzindo o problema (tamanho do array) na metade. Ou seja, $2 * T(n / 2)$. Além disso, há também uma chamada ao método Merge, que sabemos ser $O(n)$. Portanto, a relação de recorrência é:
+Lembra dos passos para determinar o tempo de execução de <a class="external" href="https://joaoarthurbm.github.io/eda/posts/analise-algoritmos-recursivos/">algoritmos recursivos</a>? O primeiro passo é encontrar a relação de recorrência. O Merge Sort possui duas chamadas recursivas, cada uma reduzindo o problema (tamanho do array) na metade. Ou seja, $2 * T(n / 2)$. Além disso, há também uma chamada ao método Merge, que sabemos ser $O(n)$. Portanto, a relação de recorrência é:
 
 <center>$T(n) = 2 * T(N / 2) + N$</center>
 
@@ -198,15 +211,15 @@ Se você ainda não entendeu como chegamos nessa relação de recorrência. Eu g
 
 {{< youtube mCzer4M_uBE >}}
 
-Então precisamos apenas resolver essa relação de recorrência. Aprendemos a fazer isso na aula sobre <a class="external" href="https://joaoarthurbm.github.io/eda/posts/analise-algoritmos-recursivos/">análise de algoritmos recursivos.</a> Há, inclusive, uma seção exclusiva para o Merge Sort neste material. Leia com atenção e volte aqui sabendo que a relação de recorrência $T(n) = 2 * T(N / 2) + N$, quando resolvida, nos fornece um custo total $n * \log n$.
+Então precisamos apenas resolver essa relação de recorrência. Aprendemos a fazer isso na aula sobre <a class="external" href="https://joaoarthurbm.github.io/eda/posts/analise-algoritmos-recursivos/">análise de algoritmos recursivos</a>. Há, inclusive, uma seção exclusiva para o Merge Sort neste material. Leia com atenção e volte aqui sabendo que a relação de recorrência $T(n) = 2 * T(N / 2) + N$, quando resolvida, nos fornece um custo total $n * \log n$.
 
-Lembra que no início do material eu afirmei que, independente caso (melhor, pior ou médio), o Merge Sort nos garante eficiência $n * \log n$? Por que? Porque as "quebras" do array sempre ocorrem na metade. Ou seja, independente dos dados, estamos sempre dividindo o array na metade. Portanto, a relação de recorrência é única e, quando resolvida, sempre nos fornece um custo $n * \log n$.
+Lembra que no início do material eu afirmei que, independente do caso (melhor, pior ou médio), o Merge Sort nos garante eficiência $n * \log n$? Por que? Porque as "quebras" do array sempre ocorrem na metade. Ou seja, independente dos dados, estamos sempre dividindo o array na metade. Portanto, a relação de recorrência é única e, quando resolvida, sempre nos fornece um custo $n * \log n$.
 
 > O Merge Sort nos garante eficiência $n * \log n$ para todos os casos.
 
 ## Análise do uso de memória
 
-Como vimos, o Merge Sort usa um array auxiliar (***helper***) na ordenação. O tamanho de helper é o mesmo do array origina. Ou seja, do ponto de vista de uso de memória, o Merge Sort é $O(n)$. 
+Como vimos, o Merge Sort usa um array auxiliar (***helper***) na ordenação. A cada etapa da divisão, novos arrays são criados para armazenar as metades que serão ordenadas. Ou seja, do ponto de vista de uso de memória, o Merge Sort é $O(n)$. 
 
 Isso é algo novo para a gente, certo? Este é o primeiro algoritmo de ordenação que estamos estudando que usa memória auxiliar proporcional ao tamanho do problema.
 


### PR DESCRIPTION
Ajusta o tamanho do array auxiliar para alocar apenas o necessário para transferir os elementos entre `left` e `right` a cada rotina do merge, em vez de criar sempre um array com o mesmo tamanho do original.