### PR TITLE
Correção de erro no texto de introdução à análise

### DIFF
--- a/content/posts/introducao-a-analise.md
+++ b/content/posts/introducao-a-analise.md
@@ -304,7 +304,7 @@ $f(n) = c_1 + c_2*(n+1) + c_3 * n + c_4 * n + $
 
 $c_5 * n + c_6 * (n^2 + n)/{2} + $
 
-$c_7 * {(n^2 - n)}/{2} + c_8 * {n^2}/{2} + c_{10}$
+$c_7 * {(n^2 - n)}/{2} + c_8 * {n^2 - n}/{2} + c_{10}$
 
 Veja que essa função é diretamente relacionada ao tamanho do array (n). À medida que cresce o tamanho de $n$, cresce também o tempo de execução do pior caso. O tempo de execução do algoritmo cresce de forma quadrática em relação ao tamanho da entrada, pois a função é quadrática. Faz sentido, certo? Comparar cada elemento de um array com todos os outros é da ordem de $n^2$.
 


### PR DESCRIPTION
correção do último exemplo, em que era citado que c8 (constante 8) se repetia a mesma quantidade de vezes que c7 (constante 7), mas no cálculo do custo total a multiplicação de ambas as constantes eram diferentes.